### PR TITLE
Add entry editing and cleanup

### DIFF
--- a/home-budget-app-java/src/main/java/com/example/homebudget/HomeBudgetAppApplication.java
+++ b/home-budget-app-java/src/main/java/com/example/homebudget/HomeBudgetAppApplication.java
@@ -2,10 +2,17 @@ package com.example.homebudget;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.filter.HiddenHttpMethodFilter;
 
 @SpringBootApplication
 public class HomeBudgetAppApplication {
     public static void main(String[] args) {
         SpringApplication.run(HomeBudgetAppApplication.class, args);
+    }
+
+    @Bean
+    public HiddenHttpMethodFilter hiddenHttpMethodFilter() {
+        return new HiddenHttpMethodFilter();
     }
 }

--- a/home-budget-app-java/src/main/java/com/example/homebudget/SecurityConfig.java
+++ b/home-budget-app-java/src/main/java/com/example/homebudget/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
             )
             .formLogin(form -> form
                 .loginPage("/logowanie")
-                .defaultSuccessUrl("/", true)
+                .defaultSuccessUrl("/dashboard", true)
                 .permitAll()
             )
             .logout(logout -> logout.logoutSuccessUrl("/"))

--- a/home-budget-app-java/src/main/java/com/example/homebudget/controller/ExpenseController.java
+++ b/home-budget-app-java/src/main/java/com/example/homebudget/controller/ExpenseController.java
@@ -2,10 +2,11 @@ package com.example.homebudget.controller;
 
 import com.example.homebudget.model.Expense;
 import com.example.homebudget.service.ExpenseService;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.math.BigDecimal;
@@ -40,16 +41,28 @@ public class ExpenseController {
     }
 
     @GetMapping("/{id}")
-    @ResponseBody
-    public ResponseEntity<Expense> get(@PathVariable Long id) {
-        return expenseService.findById(id)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+    public String edit(@PathVariable Long id, Model model) {
+        Expense expense = expenseService.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        model.addAttribute("expense", expense);
+        return "expense";
+    }
+
+    @PutMapping("/{id}")
+    public String update(@PathVariable Long id, @ModelAttribute Expense updated) {
+        Expense expense = expenseService.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        expense.setCategory(updated.getCategory());
+        expense.setDate(updated.getDate());
+        expense.setAmount(updated.getAmount());
+        expense.setNotes(updated.getNotes());
+        expenseService.save(expense);
+        return "redirect:/expenses";
     }
 
     @DeleteMapping("/{id}")
-    @ResponseBody
-    public void delete(@PathVariable Long id) {
+    public String delete(@PathVariable Long id) {
         expenseService.delete(id);
+        return "redirect:/expenses";
     }
 }

--- a/home-budget-app-java/src/main/java/com/example/homebudget/controller/IncomeController.java
+++ b/home-budget-app-java/src/main/java/com/example/homebudget/controller/IncomeController.java
@@ -2,10 +2,11 @@ package com.example.homebudget.controller;
 
 import com.example.homebudget.model.Income;
 import com.example.homebudget.service.IncomeService;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.math.BigDecimal;
@@ -40,16 +41,28 @@ public class IncomeController {
     }
 
     @GetMapping("/{id}")
-    @ResponseBody
-    public ResponseEntity<Income> get(@PathVariable Long id) {
-        return incomeService.findById(id)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+    public String edit(@PathVariable Long id, Model model) {
+        Income income = incomeService.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        model.addAttribute("income", income);
+        return "income";
+    }
+
+    @PutMapping("/{id}")
+    public String update(@PathVariable Long id, @ModelAttribute Income updated) {
+        Income income = incomeService.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        income.setCategory(updated.getCategory());
+        income.setDate(updated.getDate());
+        income.setAmount(updated.getAmount());
+        income.setNotes(updated.getNotes());
+        incomeService.save(income);
+        return "redirect:/incomes";
     }
 
     @DeleteMapping("/{id}")
-    @ResponseBody
-    public void delete(@PathVariable Long id) {
+    public String delete(@PathVariable Long id) {
         incomeService.delete(id);
+        return "redirect:/incomes";
     }
 }

--- a/home-budget-app-java/src/main/resources/static/style.css
+++ b/home-budget-app-java/src/main/resources/static/style.css
@@ -1,10 +1,6 @@
 body {
     font-family: Arial, sans-serif;
     background-color: #f0f0f0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
     margin: 0;
 }
 

--- a/home-budget-app-java/src/main/resources/templates/expense.html
+++ b/home-budget-app-java/src/main/resources/templates/expense.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wydatek</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="flex-column flex-shrink-0 p-3 bg-light" style="width:200px;">
+        <ul class="nav nav-pills flex-column mb-auto">
+            <li class="nav-item"><a th:href="@{/dashboard}" class="nav-link">Dashboard</a></li>
+            <li><a th:href="@{/expenses}" class="nav-link active">Wydatki</a></li>
+            <li><a th:href="@{/incomes}" class="nav-link">Dochody</a></li>
+            <li><a th:href="@{/account}" class="nav-link">Konto</a></li>
+        </ul>
+    </nav>
+<div class="container-fluid py-4">
+    <div class="card mb-3">
+        <div class="card-body">
+            <h3 class="card-title">Edytuj wydatek</h3>
+            <form th:action="@{/expenses/{id}(id=${expense.id})}" method="post" class="row g-2" th:object="${expense}">
+                <input type="hidden" name="_method" value="put"/>
+                <div class="col-md-3">
+                    <select class="form-select" th:field="*{category}" required>
+                        <option th:each="c : ${T(com.example.homebudget.model.ExpenseCategory).values()}" th:value="${c}" th:text="${c}"></option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <input type="number" step="0.01" th:field="*{amount}" class="form-control" required>
+                </div>
+                <div class="col-md-3">
+                    <input type="date" th:field="*{date}" class="form-control" required>
+                </div>
+                <div class="col-md-3">
+                    <button class="btn btn-primary w-100" type="submit">Zapisz</button>
+                </div>
+            </form>
+            <form th:action="@{/expenses/{id}(id=${expense.id})}" method="post" class="mt-3">
+                <input type="hidden" name="_method" value="delete"/>
+                <button class="btn btn-danger" type="submit">Usuń</button>
+            </form>
+        </div>
+    </div>
+</div>
+</div>
+</body>
+</html>

--- a/home-budget-app-java/src/main/resources/templates/income.html
+++ b/home-budget-app-java/src/main/resources/templates/income.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dochód</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="flex-column flex-shrink-0 p-3 bg-light" style="width:200px;">
+        <ul class="nav nav-pills flex-column mb-auto">
+            <li class="nav-item"><a th:href="@{/dashboard}" class="nav-link">Dashboard</a></li>
+            <li><a th:href="@{/expenses}" class="nav-link">Wydatki</a></li>
+            <li><a th:href="@{/incomes}" class="nav-link active">Dochody</a></li>
+            <li><a th:href="@{/account}" class="nav-link">Konto</a></li>
+        </ul>
+    </nav>
+<div class="container-fluid py-4">
+    <div class="card mb-3">
+        <div class="card-body">
+            <h3 class="card-title">Edytuj dochód</h3>
+            <form th:action="@{/incomes/{id}(id=${income.id})}" method="post" class="row g-2" th:object="${income}">
+                <input type="hidden" name="_method" value="put"/>
+                <div class="col-md-3">
+                    <select class="form-select" th:field="*{category}" required>
+                        <option th:each="c : ${T(com.example.homebudget.model.IncomeCategory).values()}" th:value="${c}" th:text="${c}"></option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <input type="number" step="0.01" th:field="*{amount}" class="form-control" required>
+                </div>
+                <div class="col-md-3">
+                    <input type="date" th:field="*{date}" class="form-control" required>
+                </div>
+                <div class="col-md-3">
+                    <button class="btn btn-primary w-100" type="submit">Zapisz</button>
+                </div>
+            </form>
+            <form th:action="@{/incomes/{id}(id=${income.id})}" method="post" class="mt-3">
+                <input type="hidden" name="_method" value="delete"/>
+                <button class="btn btn-danger" type="submit">Usuń</button>
+            </form>
+        </div>
+    </div>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support HTTP method override by enabling `HiddenHttpMethodFilter`
- redirect users to the dashboard after login
- fix styles so entire pages are not centered
- allow editing and deleting expenses and incomes via dedicated detail pages

## Testing
- `mvn -q test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684090b74aa8832c9b6e46f67361bccd